### PR TITLE
fix: replace <a> with Next.js <Link> for client-side routing on sign-in page

### DIFF
--- a/Dev-Sketch-Frontend/app/signin/page.tsx
+++ b/Dev-Sketch-Frontend/app/signin/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, LockIcon, Pencil, Share2, Sparkles, User2Icon, Users } from
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { HTTP_Backend } from "@/config";
+import Link from "next/link";
 
 export default function SignIn() {
     const [isLoading, setIsLoading] = useState(false);
@@ -222,12 +223,13 @@ export default function SignIn() {
                 </form>
   
                 <p className="mt-6 text-center text-sm text-zinc-400">
-                  Dont have an account? <a 
-                    href="/signup" 
+                  Don't have an account?{" "}
+                  <Link 
+                    href="/signup"
                     className="font-medium text-teal-400 hover:text-teal-300 transition-colors"
                   >
                     Sign up
-                  </a>
+                  </Link>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
This PR updates the sign-in page to use Next.js's <Link> component instead of a native <a> tag for the "Sign up" navigation link.

✅ Changes:
- Replaced `<a href="/signup">` with `<Link href="/signup">` for proper client-side routing.
- Ensures navigation is faster and avoids full page reloads.
- Follows Next.js best practices for internal navigation.

Testing:
Verified that clicking "Sign up" on the sign-in page navigates to /signup without a page reload.
Let me know if you'd like any adjustments or additions!